### PR TITLE
Deleteing only the beforeModel (which is empty) causes a test to fail

### DIFF
--- a/packages/frontend/app/routes/setup.ts
+++ b/packages/frontend/app/routes/setup.ts
@@ -1,7 +1,3 @@
 import Route from '@ember/routing/route';
 
-export default class SetupIndexRoute extends Route {
-  async beforeModel() {
-    /* intentionally empty */
-  }
-}
+export default class SetupIndexRoute extends Route {}


### PR DESCRIPTION
for some reason, the logout route's beforeModel/transitionTo('setup') fails.

no idea why.