### PR TITLE
fix: typo in german language name

### DIFF
--- a/client/web/emberclear/app/components/app/top-nav/locale-select/index.ts
+++ b/client/web/emberclear/app/components/app/top-nav/locale-select/index.ts
@@ -13,7 +13,7 @@ export default class LocaleSwitcher extends Component {
   dropdown!: HTMLDivElement;
 
   options = [
-    { locale: 'de-de', label: 'Deutsche' },
+    { locale: 'de-de', label: 'Deutsch' },
     { locale: 'en-us', label: 'English' },
     { locale: 'es-es', label: 'Español' },
     { locale: 'fr-fr', label: 'Français' },


### PR DESCRIPTION
Hi NullVoxPopuli

There was a typo in german language name and this should be fixed with this commit.
Due to some unresolved and dependency issues I was not able to run tests, yet.