### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/web-app-deploy.yml
+++ b/.github/workflows/web-app-deploy.yml
@@ -105,7 +105,7 @@ jobs:
         path: client/web/emberclear/dist/
 
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: nullvoxpopuli/emberclear
         username: ${{ secrets.DOCKERHUB_USER }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore